### PR TITLE
[WIP] Add Resource Extractor for stackdriver

### DIFF
--- a/metrics/config.go
+++ b/metrics/config.go
@@ -161,8 +161,7 @@ func (mc *metricsConfig) record(ctx context.Context, mss []stats.Measurement, ro
 
 	if mc.resourceExtractor != nil {
 		var err error
-		ctx, err = mc.resourceExtractor(mss, ctx)
-		if err != nil {
+		if ctx, err = mc.resourceExtractor(mss, ctx); err != nil {
 			return err
 		}
 	}

--- a/metrics/config_test.go
+++ b/metrics/config_test.go
@@ -995,13 +995,11 @@ func TestStackdriverRecord(t *testing.T) {
 				{Measure: servedCount, Aggregation: view.Count()},
 				{Measure: statCount, Aggregation: view.Count()},
 			}
-			//err = view.Register(v...)
-			err = RegisterResourceView(v...)
+			err = view.Register(v...)
 			if err != nil {
 				t.Errorf("Failed to register %+v in stats backend: %v", v, err)
 			}
-			//defer view.Unregister(v...)
-			defer UnregisterResourceView(v...)
+			defer view.Unregister(v...)
 
 			// Try recording each metric and checking the result.
 			Record(ctx, servedCount.M(1))

--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -267,16 +267,16 @@ func TestMetricsExport(t *testing.T) {
 				t.Fatalf("failed to read prometheus response: %+v", err)
 			}
 			want := `# HELP testComponent_global_export_counts Count of exports via standard OpenCensus view.
-		# TYPE testComponent_global_export_counts counter
-		testComponent_global_export_counts 2
-		# HELP testComponent_resource_global_export_count Count of exports via RegisterResourceView.
-		# TYPE testComponent_resource_global_export_count counter
-		testComponent_resource_global_export_count 2
-		# HELP testComponent_testing_value Test value
-		# TYPE testComponent_testing_value gauge
-		testComponent_testing_value{project="p1",revision="r1"} 0
-		testComponent_testing_value{project="p1",revision="r2"} 1
-		`
+# TYPE testComponent_global_export_counts counter
+testComponent_global_export_counts 2
+# HELP testComponent_resource_global_export_count Count of exports via RegisterResourceView.
+# TYPE testComponent_resource_global_export_count counter
+testComponent_resource_global_export_count 2
+# HELP testComponent_testing_value Test value
+# TYPE testComponent_testing_value gauge
+testComponent_testing_value{project="p1",revision="r1"} 0
+testComponent_testing_value{project="p1",revision="r2"} 1
+`
 			if diff := cmp.Diff(want, string(body)); diff != "" {
 				t.Errorf("Unexpected prometheus output (-want +got):\n%s", diff)
 			}

--- a/metrics/stackdriver_exporter.go
+++ b/metrics/stackdriver_exporter.go
@@ -196,6 +196,7 @@ func generateStackdriverOptions(config *metricsConfig, logger *zap.SugaredLogger
 }
 
 func sdResourceExtractor(mc metricsConfig) func([]stats.Measurement, context.Context) (context.Context, error) {
+	gm := getMergedGCPMetadata(&mc)
 	return func(mss []stats.Measurement, ctx context.Context) (context.Context, error) {
 		// Filter the measuremenst array to only include permitted metrics.
 		i := 0
@@ -217,7 +218,11 @@ func sdResourceExtractor(mc metricsConfig) func([]stats.Measurement, context.Con
 			tagMap := tag.FromContext(ctx)
 			r := resource.Resource{
 				Type:   templ.Type,
-				Labels: map[string]string{},
+				Labels: map[string]string{
+					metricskey.LabelProject: gm.project,
+					metricskey.LabelLocation: gm.location,
+					metricskey.LabelClusterName: gm.cluster,
+				},
 			}
 			tagMutations := make([]tag.Mutator, 0, len(templ.LabelKeys))
 			for k := range templ.LabelKeys {


### PR DESCRIPTION
There are still cleanup to do.  But I like to create the PR to discussion the issues.

The basic idea is to add a resource extractor to extract the metric tags into resource labels, and then use the resource to find the corresponding meter.  It works fine, but there are issues with existing tests.

I need to comment out a test in config_test.go, because in that test it do view.Register, then Record, and use view.RetrieveData to read the rows.  But it will fail because the default meter doesn't have any data.  Instead the data are on the other meter.  But we have no way of getting that meter to the tests.

The bigger problem is that we have similar tests in serving.  https://github.com/knative/serving/blob/master/pkg/metrics/tags_test.go#L192

The tests will fail too once we introduce meters.