### PR TITLE
Handling resource extraction when custom metrics are allowed

### DIFF
--- a/metrics/config.go
+++ b/metrics/config.go
@@ -267,9 +267,7 @@ func createMetricsConfig(ops ExporterOptions, logger *zap.SugaredLogger) (*metri
 			}
 		}
 
-		if !allowCustomMetrics {
-			mc.recorder = sdCustomMetricsRecorder(mc)
-		}
+		mc.recorder = sdCustomMetricsRecorder(mc, allowCustomMetrics)
 
 		if scc.UseSecret {
 			secret, err := getStackdriverSecret(ops.Secrets)

--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -430,7 +430,7 @@ func TestStackDriverExports(t *testing.T) {
 		},
 	}
 
-	actualPodsLabels := map[string]string{
+	label1 := map[string]string{
 		"cluster_name":       "test-cluster",
 		"configuration_name": "config",
 		"location":           "test-location",
@@ -439,7 +439,7 @@ func TestStackDriverExports(t *testing.T) {
 		"revision_name":      "revision",
 		"service_name":       "service",
 	}
-	desiredPodsLabels := map[string]string{
+	label2 := map[string]string{
 		"cluster_name":       "test-cluster",
 		"configuration_name": "config2",
 		"location":           "test-location",
@@ -448,7 +448,7 @@ func TestStackDriverExports(t *testing.T) {
 		"revision_name":      "revision2",
 		"service_name":       "service2",
 	}
-	testingValueLabels := map[string]string{
+	label3 := map[string]string{
 		"key": "value",
 	}
 	harness := []struct {
@@ -461,15 +461,15 @@ func TestStackDriverExports(t *testing.T) {
 		expected: []metricExtract{
 			{
 				"knative.dev/serving/autoscaler/actual_pods",
-				actualPodsLabels,
+				label1,
 				1,
 			},
 			{"knative.dev/serving/autoscaler/desired_pods",
-				desiredPodsLabels,
+				label2,
 				2,
 			},
 			{"custom.googleapis.com/knative.dev/autoscaler/testing/value",
-				testingValueLabels,
+				label3,
 				3,
 			},
 		},
@@ -479,11 +479,11 @@ func TestStackDriverExports(t *testing.T) {
 		expected: []metricExtract{
 			{
 				"knative.dev/serving/autoscaler/actual_pods",
-				actualPodsLabels,
+				label1,
 				1,
 			},
 			{"knative.dev/serving/autoscaler/desired_pods",
-				desiredPodsLabels,
+				label2,
 				2,
 			},
 		},

--- a/metrics/stackdriver_exporter_test.go
+++ b/metrics/stackdriver_exporter_test.go
@@ -111,14 +111,15 @@ func (me *metricExtractor) ExportMetrics(ctx context.Context, data []*metricdata
 
 func TestSdRecordWithResources(t *testing.T) {
 	testCases := []struct {
-		name             string
-		domain           string
-		component        string
-		metricName       string
-		metricTags       map[string]string
-		resource         resource.Resource
-		expectedLabels   map[string]string
-		expectedResource map[string]string
+		name               string
+		domain             string
+		component          string
+		metricName         string
+		allowCustomMetrics bool
+		metricTags         map[string]string
+		resource           resource.Resource
+		expectedLabels     map[string]string
+		expectedResource   map[string]string
 	}{{
 		name:       "Serving resource and metric labels",
 		domain:     internalServingDomain,
@@ -203,6 +204,30 @@ func TestSdRecordWithResources(t *testing.T) {
 			metricskey.LabelConfigurationName, metricskey.ValueUnknown,
 			metricskey.LabelRevisionName, testRevision),
 	}, {
+		name:       "Serving only metric labels with allowCustomMetrics",
+		domain:     internalServingDomain,
+		component:  "activator",
+		metricName: "request_count",
+		allowCustomMetrics: true,
+		metricTags: map[string]string{
+			metricskey.LabelNamespaceName:     testNS,
+			metricskey.LabelServiceName:       testService,
+			metricskey.LabelRevisionName:      testRevision,
+			metricskey.ContainerName:          testContainer,
+			metricskey.PodName:                testPod,
+			metricskey.LabelResponseCodeClass: "2xx",
+			metricskey.LabelResponseCode:      "200",
+		},
+		expectedLabels: map[string]string{
+			metricskey.ContainerName:          testContainer,
+			metricskey.PodName:                testPod,
+			metricskey.LabelResponseCodeClass: "2xx",
+			metricskey.LabelResponseCode:      "200",
+		},
+		expectedResource: makeResourceLabels(metricskey.LabelServiceName, testService,
+			metricskey.LabelConfigurationName, metricskey.ValueUnknown,
+			metricskey.LabelRevisionName, testRevision),
+	}, {
 		name:       "Eventing broker metrics",
 		domain:     internalEventingDomain,
 		component:  "broker",
@@ -223,7 +248,7 @@ func TestSdRecordWithResources(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			recordFunc := sdCustomMetricsRecorder(metricsConfig{
 				stackdriverMetricTypePrefix: path.Join(tc.domain, tc.component),
-			}, false)
+			}, tc.allowCustomMetrics)
 			m := stats.Int64(tc.metricName, "", "1")
 			v := &view.View{
 				Name:    "test_" + tc.metricName,

--- a/metrics/stackdriver_exporter_test.go
+++ b/metrics/stackdriver_exporter_test.go
@@ -223,7 +223,7 @@ func TestSdRecordWithResources(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			recordFunc := sdCustomMetricsRecorder(metricsConfig{
 				stackdriverMetricTypePrefix: path.Join(tc.domain, tc.component),
-			})
+			}, false)
 			m := stats.Int64(tc.metricName, "", "1")
 			v := &view.View{
 				Name:    "test_" + tc.metricName,


### PR DESCRIPTION
Always use custom recorder  when backend is stackdriver.

When allowCustomMetrics is true, the recorder extractor the resources from metric labels and metadata for system metrics.

When set to false, it also filter out custom metrics.