### PR TITLE
Sleep for 1ms to allow metrics being sent and received

### DIFF
--- a/metrics/resource_view_test.go
+++ b/metrics/resource_view_test.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 	"sync"
 	"testing"
+	"time"
 
 	sd "contrib.go.opencensus.io/exporter/stackdriver"
 	ocmetrics "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
@@ -333,6 +334,7 @@ testComponent_testing_value{project="p1",revision="r2"} 1
 			UnregisterResourceView(gaugeView, resourceCounter)
 			FlushExporter()
 
+			time.Sleep(1 * time.Millisecond)
 			ocFake.srv.Stop() // Force close connections
 			ocFake.srv.GracefulStop()
 			records := []metricExtract{}


### PR DESCRIPTION
On my machine the ocagent e2e test failed 1 out 4 times.  After investigation I found out it's because ocFakeSrv doesn't have enough time to process requests.

With the additional 1ms the test passed 100% of the time.